### PR TITLE
Fix images in .docx output 

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -69,16 +69,11 @@ fi
 echo "Building PDF version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-pdf asciidoctor/docker-asciidoctor asciidoctor-pdf -d book --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
 
-#cp -R $INPUT_DIR/output/* $OUTPUT_DIR/
-
 ECODE=$?
 if [ ! $ECODE -eq 0 ]; then
   echo "Build failed with exit code $ECODE"
   exit $ECODE
 fi
-
-mkdir -p $OUTPUT_DIR/img
-cp -R $INPUT_DIR/img/* $OUTPUT_DIR/img/
 
 echo "Building DOCX version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 OUTPUT_DOCBOOK="${ADOC_FILE%.*}.xml"
@@ -86,6 +81,10 @@ OUTPUT_DOCX="${ADOC_FILE%.*}.docx"
 
 echo "Building Docbook version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-docbook asciidoctor/docker-asciidoctor asciidoctor -d book --backend docbook --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
+
+mkdir -p $OUTPUT_DIR/img
+cp -R $INPUT_DIR/output/* $OUTPUT_DIR/
+cp -R $INPUT_DIR/img/* $OUTPUT_DIR/img/
 
 echo "Running pandoc to convert from $OUTPUT_DOCBOOK to $OUTPUT_DOCX in $OUTPUT_DIR"
 CDIR="$(pwd)"

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -69,8 +69,7 @@ fi
 echo "Building PDF version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-pdf asciidoctor/docker-asciidoctor asciidoctor-pdf -d book --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
 
-mkdir -p $OUTPUT_DIR
-cp -R $INPUT_DIR/output/* $OUTPUT_DIR/
+#cp -R $INPUT_DIR/output/* $OUTPUT_DIR/
 
 ECODE=$?
 if [ ! $ECODE -eq 0 ]; then
@@ -89,7 +88,10 @@ echo "Building Docbook version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-docbook asciidoctor/docker-asciidoctor asciidoctor -d book --backend docbook --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
 
 echo "Running pandoc to convert from $OUTPUT_DOCBOOK to $OUTPUT_DOCX in $OUTPUT_DIR"
-pandoc --from docbook --to docx --output $OUTPUT_DIR/$OUTPUT_DOCX $INPUT_DIR/output/$OUTPUT_DOCBOOK
+CDIR="$(pwd)"
+cd $OUTPUT_DIR
+pandoc --from docbook --to docx --output $OUTPUT_DOCX $OUTPUT_DOCBOOK
+cd $CDIR
 
 ECODE=$?
 if [ ! $ECODE -eq 0 ]; then

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -69,21 +69,6 @@ fi
 echo "Building PDF version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
 docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-pdf asciidoctor/docker-asciidoctor asciidoctor-pdf -d book --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
 
-OUTPUT_DOCBOOK="${ADOC_FILE%.*}.xml"
-OUTPUT_DOCX="${ADOC_FILE%.*}.docx"
-
-echo "Building Docbook version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
-docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-docbook asciidoctor/docker-asciidoctor asciidoctor -d book --backend docbook --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
-
-echo "Running pandoc to convert from $OUTPUT_DOCBOOK to $OUTPUT_DOCX"
-pandoc --from docbook --to docx --output $INPUT_DIR/output/$OUTPUT_DOCX $INPUT_DIR/output/$OUTPUT_DOCBOOK
-
-ECODE=$?
-if [ ! $ECODE -eq 0 ]; then
-  echo "Build failed with exit code $ECODE"
-  exit $ECODE
-fi
-
 mkdir -p $OUTPUT_DIR
 cp -R $INPUT_DIR/output/* $OUTPUT_DIR/
 
@@ -95,3 +80,19 @@ fi
 
 mkdir -p $OUTPUT_DIR/img
 cp -R $INPUT_DIR/img/* $OUTPUT_DIR/img/
+
+echo "Building DOCX version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
+OUTPUT_DOCBOOK="${ADOC_FILE%.*}.xml"
+OUTPUT_DOCX="${ADOC_FILE%.*}.docx"
+
+echo "Building Docbook version of $INPUT_DIR/$ADOC_FILE in $OUTPUT_DIR"
+docker run $RM_DOCKER -u $USER_GROUP -v $INPUT_DIR:/documents/ --name asciidoc-to-docbook asciidoctor/docker-asciidoctor asciidoctor -d book --backend docbook --attribute="commit-hash=$COMMIT_HASH" --attribute="build-date=$BUILD_DATE" -D /documents/output $ADOC_FILE
+
+echo "Running pandoc to convert from $OUTPUT_DOCBOOK to $OUTPUT_DOCX in $OUTPUT_DIR"
+pandoc --from docbook --to docx --output $OUTPUT_DIR/$OUTPUT_DOCX $INPUT_DIR/output/$OUTPUT_DOCBOOK
+
+ECODE=$?
+if [ ! $ECODE -eq 0 ]; then
+  echo "Build failed with exit code $ECODE"
+  exit $ECODE
+fi


### PR DESCRIPTION
Fix build-docs.sh so images appear in .docx.

There's still a problem with images embedded in a table in crosslinking extension doc. Possible way to fix from Claude: Use a different docx route — e.g. let asciidoctor render to HTML and convert HTML→DOCX via pandoc, which handles inline images in tables better than the docbook path.
